### PR TITLE
Correct componentName

### DIFF
--- a/src/classes/Util/FileReader.ts
+++ b/src/classes/Util/FileReader.ts
@@ -97,6 +97,7 @@ export class FileReader {
 		if (this.manifests.length === 0) {
 			this.fetchAllWorkspaceManifests();
 		}
+		
 		returnManifest = this.manifests.find(UIManifest => className.indexOf(UIManifest.componentName + ".") > -1);
 
 		return returnManifest;

--- a/src/classes/Util/FileReader.ts
+++ b/src/classes/Util/FileReader.ts
@@ -97,8 +97,7 @@ export class FileReader {
 		if (this.manifests.length === 0) {
 			this.fetchAllWorkspaceManifests();
 		}
-
-		returnManifest = this.manifests.find(UIManifest => className.indexOf(UIManifest.componentName) > -1);
+		returnManifest = this.manifests.find(UIManifest => className.indexOf(UIManifest.componentName + ".") > -1);
 
 		return returnManifest;
 	}


### PR DESCRIPTION
Problem:
In a folder with multiple apps (or workspace), if you have two apps that begin with de same name, the second app is not able to get the correct manifest.
For example:
namespace: com.APP
controller: com.APP.controller.main

namespace: com.APP_1
controller: com.APP_1.controller.name

Then:
this.manifest = [{componentName: 'com.APP'}, {componentName: 'com.APP_1'}]

The second app will get com.APP, then it is impossible to get the methods from de correct controller.

Correction:
Add a dot in the componentName to check the correct namespace