### PR TITLE
fix: i18n file path extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1 (30-04-2023)
+## 1.1.1 (05-05-2023)
 
 -   I18n extraction allow setting i18n path in 'sap.app.i18n' and 'sap.app.i18n.bundleUrl'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1 (30-04-2023)
+
+-   I18n extraction allow setting i18n path in 'sap.app.i18n' and 'sap.app.i18n.bundleUrl'
+
 ## 1.1.0 (30-04-2023)
 
 -   New command added: `UI5: (TS) Generate interfaces for OData entities (Mass)`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ui5plugin",
 	"displayName": "SAPUI5 Extension",
 	"description": "Extension for working with UI5 projects",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"publisher": "iljapostnovs",
 	"author": "Ilja Postnovs <ilja.postnovs@gmail.com>",
 	"license": "Apache-2.0",

--- a/src/classes/vscommands/i18ncommand/ExportToI18NCommand.ts
+++ b/src/classes/vscommands/i18ncommand/ExportToI18NCommand.ts
@@ -221,11 +221,13 @@ export class ExportToI18NCommand extends ParserBearer {
 		const [manifest] = this._parser.fileReader.getAllManifests();
 		const manifestFsPath = manifest?.fsPath;
 		let i18nRelativePath = manifest?.content["sap.app"]?.i18n;
-		if(typeof i18nRelativePath === "object"){
-			i18nRelativePath = i18nRelativePath.bundleUrl
+		if (typeof i18nRelativePath === "object") {
+			i18nRelativePath = i18nRelativePath.bundleUrl;
 		}
-		if(!i18nRelativePath){
-			throw new Error("Inavlid i18n bundle path valid formats are a string or an object with a property 'bundleUrl'")
+		if (!i18nRelativePath) {
+			throw new Error(
+				"Inavlid i18n bundle path in manifest.json. Please define path to i18n by setting 'sap.app.i18n' or 'sap.app.i18n.bundleUrl' field in manifest.json"
+			);
 		}
 
 		if (manifestFsPath && i18nRelativePath) {

--- a/src/classes/vscommands/i18ncommand/ExportToI18NCommand.ts
+++ b/src/classes/vscommands/i18ncommand/ExportToI18NCommand.ts
@@ -220,7 +220,14 @@ export class ExportToI18NCommand extends ParserBearer {
 	private async _insertIntoI18NFile(stringToInsert: string) {
 		const [manifest] = this._parser.fileReader.getAllManifests();
 		const manifestFsPath = manifest?.fsPath;
-		const i18nRelativePath = manifest?.content["sap.app"]?.i18n;
+		let i18nRelativePath = manifest?.content["sap.app"]?.i18n;
+		if(typeof i18nRelativePath === "object"){
+			i18nRelativePath = i18nRelativePath.bundleUrl
+		}
+		if(!i18nRelativePath){
+			throw new Error("Inavlid i18n bundle path valid formats are a string or an object with a property 'bundleUrl'")
+		}
+
 		if (manifestFsPath && i18nRelativePath) {
 			const i18nFSPath = `${manifestFsPath}${path.sep}${i18nRelativePath.replace(/\//g, path.sep)}`;
 


### PR DESCRIPTION
Hi the i18n extraction is broken when the i18n URL is not a string

The documentation for the format can be found 
here
https://sapui5.hana.ondemand.com/sdk/#/topic/be0cf40f61184b358b5faedaec98b2da.html#loiobe0cf40f61184b358b5faedaec98b2da/section_sap_app
https://sapui5.hana.ondemand.com/#/topic/ec753bc539d748f689e3ac814e129563