### PR TITLE
fixes #435 - filters out remote filesystems

### DIFF
--- a/package.json
+++ b/package.json
@@ -463,6 +463,11 @@
 					"type": "number",
 					"default": 500,
 					"markdownDescription": "Delay for parsing JS/TS files. Increase it for large projects to gain in performance."
+				},
+				"ui5.plugin.workspaceFilter": {
+					"type": "string",
+					"default": "file:///.*",
+					"markdownDescription": "Regular expression for filtering workspace root folders"
 				}
 			}
 		},

--- a/src/UI5Plugin.ts
+++ b/src/UI5Plugin.ts
@@ -43,10 +43,15 @@ export class UI5Plugin {
 	public initialize(context: vscode.ExtensionContext) {
 		return Progress.show(async () => {
 			try {
+				const workspacefilter =
+					vscode.workspace.getConfiguration("ui5.plugin").get<string>("globalConfigurationPath") ??
+					"file:///.*";
 				const workspaceFolders =
-					vscode.workspace.workspaceFolders?.map(wsFolder => {
-						return new WorkspaceFolder(wsFolder.uri.fsPath);
-					}) ?? [];
+					vscode.workspace.workspaceFolders
+						?.filter(wsFolder => wsFolder.uri.toString().match(workspacefilter))
+						?.map(wsFolder => {
+							return new WorkspaceFolder(wsFolder.uri.fsPath);
+						}) ?? [];
 
 				CommandRegistrator.register(false);
 				const globalStoragePath = context.globalStorageUri.fsPath;


### PR DESCRIPTION
filters non-file workspaces by default.
Allow overrides, might be useful in regular projects too to speed up initialization